### PR TITLE
feat: add user grouping to PR list

### DIFF
--- a/src/components/ListFooter.tsx
+++ b/src/components/ListFooter.tsx
@@ -12,8 +12,7 @@ import {
   useBreakpointValue,
 } from "@chakra-ui/react";
 import { ChangeEvent, useCallback, useState } from "react";
-import { FaRegCalendarAlt } from "react-icons/fa";
-import { FaGitAlt, FaUser } from "react-icons/fa6";
+import { FaGitAlt, FaRegCalendarAlt, FaUser } from "react-icons/fa";
 import { LuSearch } from "react-icons/lu";
 import { MdOutlineLabel } from "react-icons/md";
 import { useDebounce, useKeyPressEvent } from "react-use";

--- a/src/components/ListFooter.tsx
+++ b/src/components/ListFooter.tsx
@@ -107,7 +107,7 @@ export function ListFooter({ onSearch }: ListFooterProps) {
         )}
 
         <Select.Root
-          // colorPalette="blue"
+          colorPalette="blue"
           variant="outline"
           size="sm"
           value={[settings?.listViewBy ?? "recent"]}
@@ -118,7 +118,7 @@ export function ListFooter({ onSearch }: ListFooterProps) {
         >
           <Select.Label width="70px">Group by:</Select.Label>
           <Select.HiddenSelect />
-          <Select.Control width="180px">
+          <Select.Control width="180px" background="bg.muted">
             <Select.Trigger>
               <Select.ValueText placeholder="group by..." />
             </Select.Trigger>

--- a/src/components/ListFooter.tsx
+++ b/src/components/ListFooter.tsx
@@ -1,36 +1,39 @@
 import {
   CloseButton,
   Container,
+  createListCollection,
   For,
   HStack,
   Input,
   InputGroup,
-  RadioGroup,
-  RadioGroupValueChangeDetails,
+  Portal,
+  Select,
+  SelectValueChangeDetails,
   useBreakpointValue,
 } from "@chakra-ui/react";
 import { ChangeEvent, useCallback, useState } from "react";
+import { FaRegCalendarAlt } from "react-icons/fa";
+import { FaGitAlt, FaUser } from "react-icons/fa6";
 import { LuSearch } from "react-icons/lu";
+import { MdOutlineLabel } from "react-icons/md";
 import { useDebounce, useKeyPressEvent } from "react-use";
 import useFocus from "@/hooks/useFocus";
-import { isListViewBy, ListViewBy, useGeneralSettings } from "@/hooks/useGeneralSettings";
+import { isListViewBy, useGeneralSettings } from "@/hooks/useGeneralSettings";
 import { alpha } from "@/utils/alpha";
 import { useColorModeValue } from "./ui/color-mode";
+
+const groupBy = createListCollection({
+  items: [
+    { label: "Recently created", value: "recent", icon: <FaRegCalendarAlt /> },
+    { label: "Repo", value: "repo", icon: <FaGitAlt /> },
+    { label: "Label", value: "label", icon: <MdOutlineLabel /> },
+    { label: "User", value: "user", icon: <FaUser /> },
+  ],
+});
 
 interface ListFooterProps {
   onSearch: (value: string) => void;
 }
-
-type RadioItem = {
-  label: string;
-  value: ListViewBy;
-};
-
-const items = [
-  { label: "Recently created", value: "recent" },
-  { label: "Repo", value: "repo" },
-  { label: "Label", value: "label" },
-] as const satisfies ReadonlyArray<RadioItem>;
 
 export function ListFooter({ onSearch }: ListFooterProps) {
   const [inputRef, setInputFocus] = useFocus();
@@ -44,10 +47,10 @@ export function ListFooter({ onSearch }: ListFooterProps) {
 
   const borderColor = useColorModeValue("blue.100", "blue.900");
 
-  const handleRadioValueChange = useCallback(
-    (details: RadioGroupValueChangeDetails) => {
-      if (isListViewBy(details.value)) {
-        void updateSettings({ ...settings, listViewBy: details.value });
+  const handleSelectValueChange = useCallback(
+    (details: SelectValueChangeDetails) => {
+      if (isListViewBy(details.value[0])) {
+        void updateSettings({ ...settings, listViewBy: details.value[0] });
       }
     },
     [settings, updateSettings]
@@ -103,25 +106,44 @@ export function ListFooter({ onSearch }: ListFooterProps) {
           </InputGroup>
         )}
 
-        <RadioGroup.Root
-          colorPalette="blue"
-          variant="subtle"
-          value={settings?.listViewBy ?? "recent"}
-          onValueChange={handleRadioValueChange}
+        <Select.Root
+          // colorPalette="blue"
+          variant="outline"
+          size="sm"
+          value={[settings?.listViewBy ?? "recent"]}
+          collection={groupBy}
+          onValueChange={handleSelectValueChange}
+          flexDirection="row"
+          alignItems="baseline"
         >
-          <HStack gap="6">
-            <RadioGroup.Label>Group by:</RadioGroup.Label>
-            <For each={items}>
-              {(item) => (
-                <RadioGroup.Item key={item.value} value={item.value} cursor="pointer">
-                  <RadioGroup.ItemHiddenInput />
-                  <RadioGroup.ItemIndicator cursor="pointer" />
-                  <RadioGroup.ItemText>{item.label}</RadioGroup.ItemText>
-                </RadioGroup.Item>
-              )}
-            </For>
-          </HStack>
-        </RadioGroup.Root>
+          <Select.Label width="70px">Group by:</Select.Label>
+          <Select.HiddenSelect />
+          <Select.Control width="180px">
+            <Select.Trigger>
+              <Select.ValueText placeholder="group by..." />
+            </Select.Trigger>
+            <Select.IndicatorGroup>
+              <Select.Indicator />
+            </Select.IndicatorGroup>
+          </Select.Control>
+          <Portal>
+            <Select.Positioner>
+              <Select.Content>
+                <For each={groupBy.items}>
+                  {(item) => (
+                    <Select.Item item={item} key={item.value}>
+                      <HStack>
+                        {item.icon}
+                        {item.label}
+                      </HStack>
+                      <Select.ItemIndicator />
+                    </Select.Item>
+                  )}
+                </For>
+              </Select.Content>
+            </Select.Positioner>
+          </Portal>
+        </Select.Root>
       </HStack>
     </Container>
   );

--- a/src/components/PullRequestsList.tsx
+++ b/src/components/PullRequestsList.tsx
@@ -3,7 +3,7 @@ import { compareDesc, format, parseISO } from "date-fns";
 import { AnimatePresence } from "framer-motion";
 import { ReactNode, useCallback, useMemo, useState } from "react";
 import Favicon from "react-favicon";
-import { FaRegCalendarAlt, FaGitAlt } from "react-icons/fa";
+import { FaRegCalendarAlt, FaGitAlt, FaUser } from "react-icons/fa";
 import { MdOutlineLabel } from "react-icons/md";
 import { ListViewBy, useGeneralSettings } from "@/hooks/useGeneralSettings";
 import { PullRequest } from "@/utils/types";
@@ -27,12 +27,14 @@ const selector: Record<ListViewBy, (pull: PullRequest) => string[]> = {
   repo: (pull: PullRequest) => [pull.repository_url],
   label: (pull: PullRequest) =>
     !pull.labels?.length ? ["[unlabelled]"] : pull.labels.map((label) => label.name ?? "unknown"),
+  user: (pull: PullRequest) => [pull.user?.login ?? "unknown"],
 };
 
 const selectorIcons: Record<ListViewBy, ReactNode> = {
   recent: <FaRegCalendarAlt size={24} />,
   repo: <FaGitAlt size={24} />,
   label: <MdOutlineLabel size={24} />,
+  user: <FaUser size={24} />,
 };
 
 function isBefore(pull: PullRequest, cutoffDate?: number) {

--- a/src/hooks/useGeneralSettings.ts
+++ b/src/hooks/useGeneralSettings.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage } from "@rm-hull/use-local-storage";
 
 // Single source of truth for the allowed list view values at runtime.
-const LIST_VIEW_BY = ["repo", "recent", "label"] as const;
+const LIST_VIEW_BY = ["repo", "recent", "label", "user"] as const;
 export type ListViewBy = (typeof LIST_VIEW_BY)[number];
 
 export interface GeneralSettings {


### PR DESCRIPTION
Replaced the RadioGroup with a Select component to improve UI scalability, and added support for grouping Pull Requests by the author's username.

```mermaid
graph TD
    A[ListFooter] -->|updates| B(GeneralSettings)
    B -->|controls| C{PullRequestsList}
    C -->|groups by| D[Recent]
    C -->|groups by| E[Repo]
    C -->|groups by| F[Label]
    C -->|groups by| G[User - NEW]
```